### PR TITLE
[AWS][Cognito] Support logout endpoint

### DIFF
--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -420,7 +420,7 @@ public class TokenActivity extends AppCompatActivity {
             Intent endSessionIntent = mAuthService.getEndSessionRequestIntent(
                     new EndSessionRequest.Builder(
                         config,
-                        currentState.getIdToken(),
+                        mConfiguration.getClientId(),
                         mConfiguration.getEndSessionRedirectUri()).build());
             startActivityForResult(endSessionIntent, END_SESSION_REQUEST_CODE);
         } else {

--- a/library/java/net/openid/appauth/EndSessionResponse.java
+++ b/library/java/net/openid/appauth/EndSessionResponse.java
@@ -44,21 +44,11 @@ public class EndSessionResponse extends AuthorizationManagementResponse {
     @VisibleForTesting
     static final String KEY_REQUEST = "request";
 
-    @VisibleForTesting
-    static final String KEY_STATE = "state";
-
     /**
      * The end session request associated with this response.
      */
     @NonNull
     public final EndSessionRequest request;
-
-    /**
-     * The returned state parameter, which must match the value specified in the request.
-     * AppAuth for Android ensures that this is the case.
-     */
-    @NonNull
-    public final String state;
 
     /**
      * Creates instances of {@link EndSessionResponse}.
@@ -67,17 +57,13 @@ public class EndSessionResponse extends AuthorizationManagementResponse {
         @NonNull
         private EndSessionRequest mRequest;
 
-        @NonNull
-        private String mState;
-
-
         public Builder(@NonNull EndSessionRequest request) {
             setRequest(request);
         }
 
         @VisibleForTesting
         Builder fromUri(@NonNull Uri uri) {
-            setState(uri.getQueryParameter(EndSessionRequest.KEY_STATE));
+            // Parse uri parameters if needed (AWS Cognito does not include any)
             return this;
         }
 
@@ -86,33 +72,23 @@ public class EndSessionResponse extends AuthorizationManagementResponse {
             return this;
         }
 
-        public Builder setState(@NonNull String state) {
-            mState = checkNotEmpty(state, "state cannot be null or empty");
-            return this;
-        }
-
         /**
          * Builds the response object.
          */
         @NonNull
         public EndSessionResponse build() {
-            return new EndSessionResponse(
-                mRequest,
-                mState);
+            return new EndSessionResponse(mRequest);
         }
     }
 
-    private EndSessionResponse(
-            @NonNull EndSessionRequest request,
-            @NonNull String state) {
+    private EndSessionResponse(@NonNull EndSessionRequest request) {
         this.request = request;
-        this.state = state;
     }
 
     @Override
     @NonNull
     public String getState() {
-        return state;
+        return null; // AWS Cognito does not handle state
     }
 
     /**
@@ -124,7 +100,6 @@ public class EndSessionResponse extends AuthorizationManagementResponse {
     public JSONObject jsonSerialize() {
         JSONObject json = new JSONObject();
         JsonUtil.put(json, KEY_REQUEST, request.jsonSerialize());
-        JsonUtil.putIfNotNull(json, KEY_STATE, state);
         return json;
     }
 
@@ -146,8 +121,7 @@ public class EndSessionResponse extends AuthorizationManagementResponse {
                 EndSessionRequest.jsonDeserialize(json.getJSONObject(KEY_REQUEST));
 
         return new EndSessionResponse(
-                request,
-                JsonUtil.getString(json, KEY_STATE)
+                request
             );
     }
 

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -178,7 +178,6 @@ public class AuthorizationServiceTest {
     @Test
     public void testEndSessionRequest_withSpecifiedState() throws Exception {
         EndSessionRequest request = getTestEndSessionRequestBuilder()
-            .setState(TEST_STATE)
             .build();
         mService.performEndSessionRequest(request, mPendingIntent);
         Intent intent = captureAuthRequestIntent();

--- a/library/javatests/net/openid/appauth/EndSessionRequestTest.java
+++ b/library/javatests/net/openid/appauth/EndSessionRequestTest.java
@@ -54,25 +54,14 @@ public class EndSessionRequestTest {
     }
 
     @Test
-    public void testState_notNull() {
-        EndSessionRequest request = new EndSessionRequest.Builder(
-            getTestServiceConfig(),
-            TEST_ID_TOKEN,
-            TEST_APP_REDIRECT_URI).build();
-        assertNotNull(request.getState());
-    }
-
-    @Test
     public void testToUri() {
         EndSessionRequest request = TestValues.getTestEndSessionRequest();
         Uri requestUri = request.toUri();
 
-        assertThat(requestUri.getQueryParameter(EndSessionRequest.KEY_ID_TOKEN_HINT))
-            .isEqualTo(request.idToken);
-        assertThat(requestUri.getQueryParameter(EndSessionRequest.KEY_REDIRECT_URI))
-            .isEqualTo(request.redirectUri.toString());
-        assertThat(requestUri.getQueryParameter(EndSessionRequest.KEY_STATE))
-            .isEqualTo(request.state);
+        assertThat(requestUri.getQueryParameter(EndSessionRequest.KEY_CLIENT_ID))
+            .isEqualTo(request.clientId);
+        assertThat(requestUri.getQueryParameter(EndSessionRequest.KEY_LOGOUT_URI))
+            .isEqualTo(request.logoutUri.toString());
 
     }
 
@@ -80,9 +69,7 @@ public class EndSessionRequestTest {
     public void testJsonSerialize() throws Exception {
         EndSessionRequest resquest = TestValues.getTestEndSessionRequest();
         EndSessionRequest copy = serializeDeserialize(resquest);
-        assertThat(copy.idToken).isEqualTo(TEST_ID_TOKEN);
-        assertThat(copy.state).isEqualTo(resquest.state);
-        assertThat(copy.redirectUri).isEqualTo(resquest.redirectUri);
+        assertThat(copy.logoutUri).isEqualTo(resquest.logoutUri);
     }
 
     @Test

--- a/library/javatests/net/openid/appauth/EndSessionResponseTest.java
+++ b/library/javatests/net/openid/appauth/EndSessionResponseTest.java
@@ -21,21 +21,13 @@ public class EndSessionResponseTest {
 
     @Test(expected = NullPointerException.class)
     public void testBuilder_nullRequest(){
-        new EndSessionResponse.Builder(null)
-            .setState(TEST_REQUEST.state);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testBuilder_nullState(){
-        new EndSessionResponse.Builder(TEST_REQUEST)
-            .setState(null);
+        new EndSessionResponse.Builder(null);
     }
 
     @Test
     public void testIntentSerializeDeserialize(){
         EndSessionResponse endSessionResponse =
             new EndSessionResponse.Builder(TEST_REQUEST)
-                .setState(TEST_REQUEST.state)
                 .build();
 
         Intent endSessionIntent = endSessionResponse.toIntent();
@@ -43,15 +35,12 @@ public class EndSessionResponseTest {
         EndSessionResponse deserializeResponse = EndSessionResponse.fromIntent(endSessionIntent);
 
         assertThat(deserializeResponse).isNotNull();
-        assertThat(deserializeResponse.state).isEqualTo(endSessionResponse.request.state);
-        assertThat(deserializeResponse.request.redirectUri)
-            .isEqualTo(endSessionResponse.request.redirectUri);
+        assertThat(deserializeResponse.request.logoutUri)
+            .isEqualTo(endSessionResponse.request.logoutUri);
         assertThat(deserializeResponse.request.configuration.endSessionEndpoint)
             .isEqualTo(endSessionResponse.request.configuration.endSessionEndpoint);
-        assertThat(deserializeResponse.request.state)
-            .isEqualTo(endSessionResponse.request.state);
-        assertThat(deserializeResponse.request.idToken)
-            .isEqualTo(endSessionResponse.request.idToken);
+        assertThat(deserializeResponse.request.clientId)
+            .isEqualTo(endSessionResponse.request.clientId);
     }
 
     @Test
@@ -71,7 +60,6 @@ public class EndSessionResponseTest {
     public void testJsonSerializeDeserialize() throws JSONException {
         EndSessionResponse endSessionResponse =
             new EndSessionResponse.Builder(TEST_REQUEST)
-                .setState(TEST_REQUEST.state)
                 .build();
 
         JSONObject endSessionResponseJson = endSessionResponse.jsonSerialize();
@@ -80,26 +68,21 @@ public class EndSessionResponseTest {
             EndSessionResponse.jsonDeserialize(endSessionResponseJson);
 
         assertThat(deserializeResponse).isNotNull();
-        assertThat(deserializeResponse.state).isEqualTo(endSessionResponse.state);
-        assertThat(deserializeResponse.request.redirectUri)
-            .isEqualTo(endSessionResponse.request.redirectUri);
+        assertThat(deserializeResponse.request.logoutUri)
+            .isEqualTo(endSessionResponse.request.logoutUri);
         assertThat(deserializeResponse.request.configuration.endSessionEndpoint)
             .isEqualTo(endSessionResponse.request.configuration.endSessionEndpoint);
-        assertThat(deserializeResponse.request.state)
-            .isEqualTo(endSessionResponse.request.state);
-        assertThat(deserializeResponse.request.idToken)
-            .isEqualTo(endSessionResponse.request.idToken);
+        assertThat(deserializeResponse.request.clientId)
+            .isEqualTo(endSessionResponse.request.clientId);
     }
 
     @Test
     public void testFromRequestAndUri_Success(){
         EndSessionResponse endSessionResponse =
             new EndSessionResponse.Builder(TEST_REQUEST)
-                .setState(TEST_REQUEST.state)
                 .build();
 
         Uri endSessionUri = new Uri.Builder()
-            .appendQueryParameter(EndSessionResponse.KEY_STATE, TEST_REQUEST.state)
             .build();
 
         EndSessionResponse endSessionResponseDeserialized =
@@ -107,22 +90,18 @@ public class EndSessionResponseTest {
                 .fromUri(endSessionUri)
                 .build();
         assertThat(endSessionResponseDeserialized).isNotNull();
-        assertThat(endSessionResponseDeserialized.state).isEqualTo(endSessionResponse.state);
-        assertThat(endSessionResponseDeserialized.request.redirectUri)
-            .isEqualTo(endSessionResponse.request.redirectUri);
+        assertThat(endSessionResponseDeserialized.request.logoutUri)
+            .isEqualTo(endSessionResponse.request.logoutUri);
         assertThat(endSessionResponseDeserialized.request.configuration.endSessionEndpoint)
             .isEqualTo(endSessionResponse.request.configuration.endSessionEndpoint);
-        assertThat(endSessionResponseDeserialized.request.state)
-            .isEqualTo(endSessionResponse.request.state);
-        assertThat(endSessionResponseDeserialized.request.idToken)
-            .isEqualTo(endSessionResponse.request.idToken);
+        assertThat(endSessionResponseDeserialized.request.clientId)
+            .isEqualTo(endSessionResponse.request.clientId);
     }
 
     @Test
     public void testIntent_containsEndSessionResponse_True() {
         EndSessionResponse endSessionResponse =
             new EndSessionResponse.Builder(TEST_REQUEST)
-                .setState(TEST_REQUEST.state)
                 .build();
 
         Intent endSessionIntent = endSessionResponse.toIntent();


### PR DESCRIPTION


<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [ ] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [ ] I ran, updated and added unit tests as necessary.
- [ ] I verified the contribution matches existing coding style.
- [ ] I updated the documentation if necessary.

### Motivation and Context
It adapt end session request to not require state match and includes 'client_id' query parameter to support AWS Cognito LOGOUT endpoint which is not following OpenID spec.
